### PR TITLE
Make the return code reflect the global result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 bin
 obj
+
+.fake
+.ionide
+node_modules/

--- a/Prelude.fs
+++ b/Prelude.fs
@@ -1,5 +1,11 @@
 namespace Femto
 
+type FemtoResult =
+    | ValidationSucceeded = 0
+    | MissingPackageJson = 1
+    | NodeModulesNotInstalled = 2
+    | ValidationFailed = 3
+
 type ResizeArrayDictionary<'K, 'V when 'K : equality>() =
     let dic = System.Collections.Generic.Dictionary<'K, ResizeArray<'V>>()
     member __.Count = dic.Count


### PR DESCRIPTION
Fix #1

In #1, we mentionned `LibraryNotInstalled`and `VersionMismatch` as possible results but this is not possible at the `ExitCode` level.

The `ExitCode` can only represents:
- `ValidationSucceeded`: All the deps are valid
- `MissingPackageJson`: Cannot find the `package.json`
- `NodeModulesNotInstalled`: The user need to restore the npm deps using `yarn/npm install`
- `ValidationFailed`: `At least one of the deps validation failed`