### PR TITLE
Remove InstallHint property by finding on the fly the version to install

### DIFF
--- a/Femto.fsproj
+++ b/Femto.fsproj
@@ -20,6 +20,9 @@
     <PackageReference Include="Dotnet.ProjInfo" Version="0.35.0" />
     <PackageReference Include="FSharp.Compiler.Service" Version="29.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Thoth.Json.Net" Version="3.4.0" />
+    <PackageReference Include="Fable.Core" Version="3.0.0" />
+    <PackageReference Include="Fake.Core.Process" Version="5.15.0" />
     <PackageReference Include="SemanticVersioning" Version="1.2.0" />
     <PackageReference Include="Serilog" Version="2.8.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />

--- a/Npm.fs
+++ b/Npm.fs
@@ -64,9 +64,13 @@ let parseDependencies (project: string) =
             let lowestMatching =
                 "Strategy"
                 |> elementsByTag (rootNode :?> XmlElement)
-                |> List.head
-                |> tryBoolAttr "LowestMatching"
-                |> Option.defaultValue true
+                |> List.tryHead
+                |> function
+                    | Some head ->
+                        head
+                        |> tryBoolAttr "LowestMatching"
+                        |> Option.defaultValue true
+                    | None -> true
 
             let npmPackages =
                 "NpmPackage"
@@ -83,4 +87,6 @@ let parseDependencies (project: string) =
             true, []
     with
         | ex ->
+            logger.Error("An error occured when parsing for dependencies")
+            logger.Error(ex.Message)
             true, []

--- a/Npm.fs
+++ b/Npm.fs
@@ -1,14 +1,17 @@
 module Femto.Npm
 
+open Serilog
 open System.IO
 open System.Xml
 open SemVer
+
+let logger = LoggerConfiguration().WriteTo.Console().CreateLogger()
 
 type NpmDependency = {
     Name: string
     Constraint: Range option
     RawVersion : string
-    InstallHint: string
+    LowestMatching : bool option
 }
 
 type InstalledNpmPackage = {
@@ -30,11 +33,26 @@ let elementsByTag (el: XmlElement) tag =
     let elements = el.GetElementsByTagName tag
     [ for i in 0 .. elements.Count - 1 -> elements.Item i ]
 
-let attr (name: string) (node: XmlNode)  =
+let tryAttr (name: string) (node: XmlNode) =
     [ for i in 0 .. node.Attributes.Count - 1 -> node.Attributes.Item(i) :?> XmlAttribute ]
     |> List.tryFind (fun attr -> attr.Name = name)
     |> Option.map (fun attr -> attr.Value)
+
+let attr (name: string) (node: XmlNode)  =
+    tryAttr name node
     |> Option.defaultValue ""
+
+let tryBoolAttr (name : string) (node : XmlNode) =
+    tryAttr name node
+    |> Option.map (fun value ->
+        match System.Boolean.TryParse(value) with
+        | true, res ->
+            res
+
+        | false, _ ->
+            logger.Warning("Invalid value for '{AttributeName}' attribute. Accepted values are 'true' or 'false'", name)
+            true
+    )
 
 let parseDependencies (project: string) =
     try
@@ -43,15 +61,26 @@ let parseDependencies (project: string) =
         let npmDependencies = elementsByTag doc.DocumentElement "NpmDependencies"
         match npmDependencies with
         | [ rootNode ] ->
-            "NpmPackage"
-            |> elementsByTag (rootNode :?> XmlElement)
-            |> List.map (fun node -> {
-                   Name = attr "Name" node;
-                   RawVersion = attr "Version" node
-                   Constraint = parseConstraint (attr "Version" node)
-                   InstallHint = attr "InstallHint" node
-                })
+            let lowestMatching =
+                "Strategy"
+                |> elementsByTag (rootNode :?> XmlElement)
+                |> List.head
+                |> tryBoolAttr "LowestMatching"
+                |> Option.defaultValue true
+
+            let npmPackages =
+                "NpmPackage"
+                |> elementsByTag (rootNode :?> XmlElement)
+                |> List.map (fun node -> {
+                        Name = attr "Name" node;
+                        RawVersion = attr "Version" node
+                        Constraint = parseConstraint (attr "Version" node)
+                        LowestMatching = tryBoolAttr "LowestMatching" node
+                    })
+
+            lowestMatching, npmPackages
         | _ ->
-            []
+            true, []
     with
-    | ex -> []
+        | ex ->
+            true, []

--- a/Program.fs
+++ b/Program.fs
@@ -160,7 +160,7 @@ let private printInstallHint (nodeManager : NodeManager) (library : LibraryWithN
                 match pkg.LowestMatching with
                 | Some pkgLowestMatching ->
                     if library.LowestMatching <> pkgLowestMatching then
-                        logger.Information("  | -- Resolution strategy override to lowest matching: {Strategy}", pkg.LowestMatching)
+                        logger.Information("  | -- Resolution strategy override to lowest matching: {Strategy}", pkgLowestMatching)
                         pkgLowestMatching
                     else
                         library.LowestMatching

--- a/Program.fs
+++ b/Program.fs
@@ -6,15 +6,32 @@ open Npm
 open Newtonsoft.Json.Linq
 open FSharp.Compiler.AbstractIL.Internal.Library
 open System.Diagnostics
+open Fake.Core
+open Thoth.Json.Net
 
 let logger = LoggerConfiguration().WriteTo.Console().CreateLogger()
 
-let findNpmDependencies (project: CrackedFsproj) =
+type LibraryWithNpmDeps = {
+    Path : string
+    Name : string
+    NpmDependencies : NpmDependency list
+    LowestMatching : bool
+}
+
+let findLibraryWithNpmDeps (project: CrackedFsproj) =
     [ yield project.ProjectFile
       yield! project.ProjectReferences
       for package in project.PackageReferences do yield package.FsprojPath ]
-    |> List.map (fun proj -> proj, Path.GetFileNameWithoutExtension proj, Npm.parseDependencies (Path.normalizeFullPath proj))
-    |> List.filter (fun (path, name, deps) -> not (List.isEmpty deps))
+    |> List.map (fun proj ->
+        let (lowestMatching, npmDeps) = Npm.parseDependencies (Path.normalizeFullPath proj)
+        {
+            Path = proj
+            Name = Path.GetFileNameWithoutExtension proj
+            LowestMatching = lowestMatching
+            NpmDependencies = npmDeps
+        }
+    )
+    |> List.filter (fun projet -> not (List.isEmpty projet.NpmDependencies))
 
 let rec findPackageJson (project: string) =
     let parentDir = IO.Directory.GetParent project
@@ -24,6 +41,26 @@ let rec findPackageJson (project: string) =
       |> IO.Directory.GetFiles
       |> Seq.tryFind (fun file -> file.EndsWith "package.json")
       |> Option.orElse (findPackageJson parentDir.FullName)
+
+[<RequireQualifiedAccess>]
+type NodeManager =
+    | Yarn
+    | Npm
+
+    member this.CommandName =
+        match this with
+        | Yarn -> "yarn"
+        | Npm -> "npm"
+
+let workspaceCommand (packageJson: string) =
+    let parentDir = IO.Directory.GetParent packageJson
+    let siblings = [ yield! IO.Directory.GetFiles parentDir.FullName; yield! IO.Directory.GetDirectories parentDir.FullName ]
+    let nodeModulesExists = siblings |> List.exists (fun file -> file.EndsWith "node_modules")
+    let yarnLockExists = siblings |> List.exists (fun file -> file.EndsWith "yarn.lock")
+    let packageLockExists = siblings |> List.exists (fun file -> file.EndsWith "package-lock.json")
+    if nodeModulesExists then NodeManager.Npm
+    elif yarnLockExists then NodeManager.Yarn
+    else NodeManager.Npm
 
 let needsNodeModules (packageJson: string) =
     let parentDir = IO.Directory.GetParent packageJson
@@ -93,31 +130,86 @@ let findInstalledPackages (packageJson: string) : ResizeArray<InstalledNpmPackag
     | _ ->
         topLevelPackages
 
-let rec checkPackage
-    (packages : NpmDependency list)
+let private printInstallHint (nodeManager : NodeManager) (library : LibraryWithNpmDeps) (pkg : NpmDependency) =
+
+    let packageVersions =
+        match nodeManager with
+        | NodeManager.Npm ->
+            let res =
+                CreateProcess.fromRawCommand "npm" [ "show"; pkg.Name; "versions"; "--json" ]
+                |> CreateProcess.redirectOutput
+                |> CreateProcess.ensureExitCode
+                |> Proc.run
+
+            Decode.unsafeFromString (Decode.list Decode.string) res.Result.Output
+
+        | NodeManager.Yarn ->
+            let res =
+                CreateProcess.fromRawCommand "yarn" [ "info"; pkg.Name; "versions"; "--json" ]
+                |> CreateProcess.redirectOutput
+                |> CreateProcess.ensureExitCode
+                |> Proc.run
+
+            Decode.unsafeFromString (Decode.field "data" (Decode.list Decode.string)) res.Result.Output
+
+    let maxSatisfyingVersion =
+        pkg.Constraint
+        |> Option.map (fun range ->
+            let lowestMatching =
+                // Can we resolve this using Boolean algebra?
+                match pkg.LowestMatching with
+                | Some pkgLowestMatching ->
+                    if library.LowestMatching <> pkgLowestMatching then
+                        logger.Information("  | -- Resolution strategy override to lowest matching: {Strategy}", pkg.LowestMatching)
+                        pkgLowestMatching
+                    else
+                        library.LowestMatching
+                | None ->
+                    library.LowestMatching
+
+            if lowestMatching then
+                packageVersions
+                |> Seq.cast<string>
+                |> range.Satisfying
+                |> Seq.head
+            else
+                packageVersions
+                |> Seq.cast<string>
+                |> range.MaxSatisfying
+        )
+
+    match maxSatisfyingVersion with
+    | Some maxSatisfyingVersion ->
+        let hint =
+            sprintf "%s install %s@%s" nodeManager.CommandName pkg.Name maxSatisfyingVersion
+
+        logger.Error("  | -- Resolve this issue using '{Hint}'", hint)
+    | None -> ()
+
+let rec checkPackages
+    (nodeManager : NodeManager)
+    (library : LibraryWithNpmDeps)
+    (packagesToVerify : NpmDependency list)
     (installedPackages : ResizeArray<InstalledNpmPackage>)
-    (libraryName : string)
     (isOk : bool) =
 
-    match packages with
+    match packagesToVerify with
     | pkg::rest ->
         logger.Information("")
         let installed = installedPackages |> Seq.tryFind (fun p -> p.Name = pkg.Name)
         let result =
             match installed with
             | None ->
-                logger.Error("{Library} depends on npm package '{Package}'", libraryName, pkg.Name, pkg.RawVersion)
+                logger.Error("{Library} depends on npm package '{Package}'", library.Name, pkg.Name, pkg.RawVersion)
                 logger.Error("  | -- Required range {Range} found in project file", pkg.Constraint |> Option.map string |> Option.defaultValue pkg.RawVersion)
                 logger.Error("  | -- Missing '{package}' in package.json", pkg.Name)
-                if pkg.InstallHint <> ""
-                then logger.Error("  | -- Resolve this issue using {Hint}", pkg.InstallHint)
-
+                printInstallHint nodeManager library pkg
                 false
 
             | Some installedPackage  ->
                 match installedPackage.Range, installedPackage.Installed with
                 | Some range, Some version ->
-                    logger.Information("{Library} depends on npm package '{Package}'", libraryName, pkg.Name);
+                    logger.Information("{Library} depends on npm package '{Package}'", library.Name, pkg.Name);
                     logger.Information("  | -- Required range {Range} found in project file", pkg.Constraint |> Option.map string |> Option.defaultValue pkg.RawVersion)
                     logger.Information("  | -- Used range {Range} in package.json", range.ToString())
                     match pkg.Constraint with
@@ -127,29 +219,31 @@ let rec checkPackage
 
                     | _ ->
                         logger.Error("  | -- Installed version {Version} does not satisfy required range {Range}", version.ToString(), pkg.Constraint |> Option.map string |> Option.defaultValue pkg.RawVersion)
-                        if pkg.InstallHint <> ""
-                        then logger.Error("  | -- Resolve this issue using {Hint}", pkg.InstallHint)
+                        printInstallHint nodeManager library pkg
                         false
 
                 | _ ->
-                    logger.Error("{Library} requires npm package '{Package}' ({Version}) which was not installed", libraryName, pkg.Name, pkg.Constraint.ToString())
+                    logger.Error("{Library} requires npm package '{Package}' ({Version}) which was not installed", library.Name, pkg.Name, pkg.Constraint.ToString())
                     false
 
-        checkPackage rest installedPackages libraryName (isOk && result)
+        checkPackages nodeManager library rest installedPackages (isOk && result)
     | [] ->
         isOk
 
 let rec analyzePackages
-    (npmDependencies : (string * string * NpmDependency list) list)
+    (nodeManager : NodeManager)
+    (libraries : LibraryWithNpmDeps list)
     (installedPackages : ResizeArray<InstalledNpmPackage>)
     (isOk : bool) =
 
-    match npmDependencies with
-    | (path, libraryName, packages)::rest ->
-        let result =
-            checkPackage packages installedPackages libraryName true
+    match libraries with
+    | library::rest ->
+        logger.Information("Resolution strategy for {Library} is lowest matching: {LowestMatching}", library.Name, library.LowestMatching)
 
-        analyzePackages rest installedPackages (isOk && result)
+        let result =
+            checkPackages nodeManager library library.NpmDependencies installedPackages true
+
+        analyzePackages nodeManager rest installedPackages (isOk && result)
     | [] ->
         isOk
 
@@ -170,14 +264,14 @@ let main argv =
 
     logger.Information("Analyzing project {Project}", project)
     let projectInfo = ProjectCracker.fullCrack project
-    let npmDependencies = findNpmDependencies projectInfo
+    let libraries = findLibraryWithNpmDeps projectInfo
 
     let result =
         match findPackageJson project with
         | None ->
-            for (path, name, packages) in npmDependencies do
-                for pkg in packages do
-                    logger.Information("{Library} requires npm package {Package} ({Version})", name, pkg.Name, pkg.RawVersion)
+            for library in libraries do
+                for pkg in library.NpmDependencies do
+                    logger.Information("{Library} requires npm package {Package} ({Version})", library.Name, pkg.Name, pkg.RawVersion)
             logger.Warning "Could not locate package.json file"
 
             FemtoResult.MissingPackageJson
@@ -192,8 +286,9 @@ let main argv =
 
             | None ->
                 let installedPackages = findInstalledPackages packageJson
+                let nodeManager = workspaceCommand packageJson
 
-                if analyzePackages npmDependencies installedPackages true then
+                if analyzePackages nodeManager libraries installedPackages true then
                     FemtoResult.ValidationSucceeded
                 else
                     FemtoResult.ValidationFailed

--- a/README.md
+++ b/README.md
@@ -34,8 +34,20 @@ In order for Femto to pick up the npm packages that your library depends upon, y
 ```xml
 <PropertyGroup>
   <NpmDependencies>
-      <NpmPackage Name="date-fns" Version=">= 1.30.0" InstallHint="npm install date-fns@1.30" />
+      <NpmPackage Name="date-fns" Version=">= 1.30.0" />
   </NpmDependencies>
 </PropertyGroup>
 ```
-Notice here in the example, we have one npm package we depend upon which has requires a version that satisfies that range `>= 1.30.0`. If the user doesn't have that version installed or has an old version, a message will appear telling them how to solve the issue by running the command given in the `InstallHint`
+Notice here in the example, we have one npm package we depend upon which has requires a version that satisfies that range `>= 1.30.0`. If the user doesn't have that version installed or has an old version, a message will appear telling them how to solve the issue.
+
+--------
+
+You can customize the resolution strategy by adding `ResolutionStrategy` attribute to an `NpmPackage` node. Accepted values are `min` and `max`. If `ResolutionStrategy` is not set, we default to `min` strategy.
+
+```xml
+<PropertyGroup>
+  <NpmDependencies>
+      <NpmPackage Name="date-fns" Version=">= 1.30.0" ResolutionStrategy="max" />
+  </NpmDependencies>
+</PropertyGroup>
+```


### PR DESCRIPTION
Fix #3

Included in this PR:

- Remove the `InstallHint` property
- Resolve the version to install using `yarn info <package> versions --json` or `npm show <package> versions --json`
- Add the possibility to configure `LowestMatching` globally
- Add the possibility to override the global `LowestMatching` per dependency
- Refactor to use `types` instead of `tuples` because I was adding a new one with `LowestMatching`

When adding the new `types` I tried to find "good" names but I am not certain of them. If you come up with better naming don't hesitate to tell me. :)

⚠️ I tried to add `LowestMatching` to `NpmDependencies` but it made `ProjectCracker` crash. `dotnet restore` was working fine. So I guess the `ProjectCracker` library has a bug/limitation here.

This is for this reason, that I added `<Strategy LowestMatching="false" />` as a child of `NpmDependencies` node.

If `<Strategy LowestMatching="false" />` is not set, then the resolution is set to `LowestMatching = true`.

Example of output:

## By default `LowestMatching` is set to `true`

```xml
<Project Sdk="Microsoft.NET.Sdk">
    <PropertyGroup>
        <OutputType>Exe</OutputType>
        <TargetFramework>netcoreapp3.0</TargetFramework>
    </PropertyGroup>
    <ItemGroup>
        <Compile Include="Main.fs" />
    </ItemGroup>
    <PropertyGroup>
        <NpmDependencies>
            <NpmPackage Name="date-fns" Version=">= 1.30.0"/>
            <NpmPackage Name="bulma" Version=">= 0.6.0" />
            <NpmPackage Name="password-generator" Version=">= 1.0.0"/>
        </NpmDependencies>
    </PropertyGroup>
</Project>
```

```
[17:45:21 INF] Analyzing project /Users/maximemangel/Workspaces/Github/Zaid-Ajaj/FemtoTest/NpmPackageNotInstalled/NpmPackageNotInstalled.fsproj
[17:45:24 INF] Resolution strategy for NpmPackageNotInstalled is lowest matching: True
[17:45:24 INF] 
[17:45:24 ERR] NpmPackageNotInstalled depends on npm package 'date-fns'
[17:45:24 ERR]   | -- Required range >= 1.30.0 found in project file
[17:45:24 ERR]   | -- Missing 'date-fns' in package.json
[17:45:25 ERR]   | -- Resolve this issue using 'npm install date-fns@1.30.1'
[17:45:25 INF] 
[17:45:25 ERR] NpmPackageNotInstalled depends on npm package 'bulma'
[17:45:25 ERR]   | -- Required range >= 0.6.0 found in project file
[17:45:25 ERR]   | -- Missing 'bulma' in package.json
[17:45:25 ERR]   | -- Resolve this issue using 'npm install bulma@0.6.0'
[17:45:25 INF] 
[17:45:25 ERR] NpmPackageNotInstalled depends on npm package 'password-generator'
[17:45:25 ERR]   | -- Required range >= 1.0.0 found in project file
[17:45:25 ERR]   | -- Missing 'password-generator' in package.json
[17:45:26 ERR]   | -- Resolve this issue using 'npm install password-generator@1.0.0'
```

## Set `LowestMatching` to `false`

```xml
<Project Sdk="Microsoft.NET.Sdk">
    <PropertyGroup>
        <OutputType>Exe</OutputType>
        <TargetFramework>netcoreapp3.0</TargetFramework>
    </PropertyGroup>
    <ItemGroup>
        <Compile Include="Main.fs" />
    </ItemGroup>
    <PropertyGroup>
        <NpmDependencies>
            <Strategy LowestMatching="false" />
            <NpmPackage Name="date-fns" Version=">= 1.30.0"/>
            <NpmPackage Name="bulma" Version=">= 0.6.0"/>
            <NpmPackage Name="password-generator" Version=">= 1.0.0"/>
        </NpmDependencies>
    </PropertyGroup>
</Project>
```

```
[17:46:46 INF] Analyzing project /Users/maximemangel/Workspaces/Github/Zaid-Ajaj/FemtoTest/NpmPackageNotInstalled/NpmPackageNotInstalled.fsproj
[17:46:49 INF] Resolution strategy for NpmPackageNotInstalled is lowest matching: False
[17:46:49 INF] 
[17:46:49 ERR] NpmPackageNotInstalled depends on npm package 'date-fns'
[17:46:49 ERR]   | -- Required range >= 1.30.0 found in project file
[17:46:49 ERR]   | -- Missing 'date-fns' in package.json
[17:46:50 ERR]   | -- Resolve this issue using 'npm install date-fns@1.30.1'
[17:46:50 INF] 
[17:46:50 ERR] NpmPackageNotInstalled depends on npm package 'bulma'
[17:46:50 ERR]   | -- Required range >= 0.6.0 found in project file
[17:46:50 ERR]   | -- Missing 'bulma' in package.json
[17:46:51 ERR]   | -- Resolve this issue using 'npm install bulma@0.7.5'
[17:46:51 INF] 
[17:46:51 ERR] NpmPackageNotInstalled depends on npm package 'password-generator'
[17:46:51 ERR]   | -- Required range >= 1.0.0 found in project file
[17:46:51 ERR]   | -- Missing 'password-generator' in package.json
[17:46:51 ERR]   | -- Resolve this issue using 'npm install password-generator@2.2.0'
```

## Override `LowestMatching` for `bulma` only

```xml
<Project Sdk="Microsoft.NET.Sdk">
    <PropertyGroup>
        <OutputType>Exe</OutputType>
        <TargetFramework>netcoreapp3.0</TargetFramework>
    </PropertyGroup>
    <ItemGroup>
        <Compile Include="Main.fs" />
    </ItemGroup>
    <PropertyGroup>
        <NpmDependencies>
            <NpmPackage Name="date-fns" Version=">= 1.30.0"/>
            <NpmPackage Name="bulma" Version=">= 0.6.0" LowestMatching="false"/>
            <NpmPackage Name="password-generator" Version=">= 1.0.0"/>
        </NpmDependencies>
    </PropertyGroup>
</Project>
```

```
[17:48:18 INF] Analyzing project /Users/maximemangel/Workspaces/Github/Zaid-Ajaj/FemtoTest/NpmPackageNotInstalled/NpmPackageNotInstalled.fsproj
[17:48:21 INF] Resolution strategy for NpmPackageNotInstalled is lowest matching: True
[17:48:21 INF] 
[17:48:21 ERR] NpmPackageNotInstalled depends on npm package 'date-fns'
[17:48:21 ERR]   | -- Required range >= 1.30.0 found in project file
[17:48:21 ERR]   | -- Missing 'date-fns' in package.json
[17:48:22 ERR]   | -- Resolve this issue using 'npm install date-fns@1.30.1'
[17:48:22 INF] 
[17:48:22 ERR] NpmPackageNotInstalled depends on npm package 'bulma'
[17:48:22 ERR]   | -- Required range >= 0.6.0 found in project file
[17:48:22 ERR]   | -- Missing 'bulma' in package.json
[17:48:23 INF]   | -- Resolution strategy override to lowest matching: False
[17:48:23 ERR]   | -- Resolve this issue using 'npm install bulma@0.7.5'
[17:48:23 INF] 
[17:48:23 ERR] NpmPackageNotInstalled depends on npm package 'password-generator'
[17:48:23 ERR]   | -- Required range >= 1.0.0 found in project file
[17:48:23 ERR]   | -- Missing 'password-generator' in package.json
[17:48:23 ERR]   | -- Resolve this issue using 'npm install password-generator@1.0.0'
```