### PR TITLE
Use argu

### DIFF
--- a/Femto.fsproj
+++ b/Femto.fsproj
@@ -17,6 +17,7 @@
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Argu" Version="5.5.0" />
     <PackageReference Include="Dotnet.ProjInfo" Version="0.35.0" />
     <PackageReference Include="FSharp.Compiler.Service" Version="29.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />

--- a/Prelude.fs
+++ b/Prelude.fs
@@ -1,25 +1,15 @@
 namespace Femto
 
 type FemtoResult =
+    | UnexpectedError = -1
     | ValidationSucceeded = 0
     | MissingPackageJson = 1
     | NodeModulesNotInstalled = 2
     | ValidationFailed = 3
     | ProjectFileNotFound = 4
     | ProjectCrackerFailed = 5
-    | UnexpectedError = -1
-
-
-module FemtoResult =
-    let fromCode = function
-    | 0 -> FemtoResult.ValidationSucceeded
-    | 1 -> FemtoResult.MissingPackageJson
-    | 2 -> FemtoResult.NodeModulesNotInstalled
-    | 3 -> FemtoResult.ValidationFailed
-    | 4 -> FemtoResult.ProjectFileNotFound
-    | 5 -> FemtoResult.ProjectCrackerFailed
-    | n -> FemtoResult.UnexpectedError
-
+    | UsageRequested = 6
+    | InvalidArguments = 7
 
 type ResizeArrayDictionary<'K, 'V when 'K : equality>() =
     let dic = System.Collections.Generic.Dictionary<'K, ResizeArray<'V>>()

--- a/Program.fs
+++ b/Program.fs
@@ -600,8 +600,8 @@ type CLIArguments =
         member this.Usage =
             match this with
             | Project _ -> "specify the path to the F# project"
-            | Validate -> "check that the XML tags used in the F# project file is parsable and a npm package version can be calculated"
-            | Resolve -> "resolve package resolution and apply the required actions"
+            | Validate -> "check that the XML tags used in the F# project file are parsable and a npm package version can be calculated"
+            | Resolve -> "resolve and install required packages"
             | Preview -> "preview required actions for package resolution"
 
 let parseArgs (cliArgs : CLIArguments list) =

--- a/Program.fs
+++ b/Program.fs
@@ -71,10 +71,7 @@ let needsNodeModules (packageJson: string) =
     let parentDir = IO.Directory.GetParent packageJson
     let siblings = [ yield! IO.Directory.GetFiles parentDir.FullName; yield! IO.Directory.GetDirectories parentDir.FullName ]
     let nodeModulesExists = siblings |> List.exists (fun file -> file.EndsWith "node_modules")
-    let yarnLockExists = siblings |> List.exists (fun file -> file.EndsWith "yarn.lock")
-    if nodeModulesExists then false
-    elif yarnLockExists then true
-    else true
+    not nodeModulesExists
 
 let findInstalledPackages (packageJson: string) : ResizeArray<InstalledNpmPackage> =
     let parentDir = IO.Directory.GetParent packageJson


### PR DESCRIPTION
Fix #18

In Unix, the presence or absence of an argument is what triggers the `true` or `false` state.

So if the user wants to activate the `resolve` mode, he needs to write `--resolve` no need for `--resolve true`.

If we want to disable something, in general, we add an argument like `--no-resolve`. 

For our use cases, because by default, all the options are disabled I only added `--resolve` & Co.

**Help preview**
```
USAGE: femto [--help] [--validate] [--resolve] [--preview] <path>

PROJECT:

    <path>                specify the path to the F# project

OPTIONS:

    --validate            check that the XML tags used in the F# project file is parsable and a npm
                          package version can be calculated
    --resolve             resolve package resolution and apply the required actions
    --preview             preview required actions for package resolution
    --help                display this list of options.
```