### PR TITLE
Automatic conflict resolution and dev dependency implementation

### DIFF
--- a/Program.fs
+++ b/Program.fs
@@ -469,14 +469,14 @@ let resolveConflicts (actions: ResolveAction list) =
                         |> List.tryHead
                         |> function
                             | None ->
-                                ResolveAction.Install(libName, pkgName, version.ToString(), String.concat " || " rangeStrings)
+                                ResolveAction.Install(libName, pkgName, version.ToString(), String.concat " && " rangeStrings)
                             | Some problematicRange ->
                                 if not (problematicRange.IsSatisfied version)
                                 then
-                                    let errorMsg = sprintf "Resolved version %s satisfies [%s] but not %s" (version.ToString()) (String.concat " || " rangeStrings) (problematicRange.ToString())
+                                    let errorMsg = sprintf "Resolved version %s satisfies [%s] but not %s" (version.ToString()) (String.concat " && " rangeStrings) (problematicRange.ToString())
                                     ResolveAction.UnableToResolve(libName, pkgName, problematicRange.ToString(), errorMsg)
                                 else
-                                    ResolveAction.Install(libName, pkgName, version.ToString(), String.concat " || " rangeStrings)
+                                    ResolveAction.Install(libName, pkgName, version.ToString(), String.concat " && " rangeStrings)
         )
 
     let distinctInstallDevActions =
@@ -535,14 +535,14 @@ let resolveConflicts (actions: ResolveAction list) =
                         |> List.tryHead
                         |> function
                             | None ->
-                                ResolveAction.InstallDev(libName, pkgName, version.ToString(), String.concat " || " rangeStrings)
+                                ResolveAction.InstallDev(libName, pkgName, version.ToString(), String.concat " && " rangeStrings)
                             | Some problematicRange ->
                                 if not (problematicRange.IsSatisfied version)
                                 then
-                                    let errorMsg = sprintf "Resolved version %s satisfies [%s] but not %s" (version.ToString()) (String.concat " || " rangeStrings) (problematicRange.ToString())
+                                    let errorMsg = sprintf "Resolved version %s satisfies [%s] but not %s" (version.ToString()) (String.concat " && " rangeStrings) (problematicRange.ToString())
                                     ResolveAction.UnableToResolve(libName, pkgName, problematicRange.ToString(), errorMsg)
                                 else
-                                    ResolveAction.InstallDev(libName, pkgName, version.ToString(), String.concat " || " rangeStrings)
+                                    ResolveAction.InstallDev(libName, pkgName, version.ToString(), String.concat " && " rangeStrings)
         )
 
     let unresolvableActions =

--- a/Program.fs
+++ b/Program.fs
@@ -18,11 +18,14 @@ type LibraryWithNpmDeps = {
     NpmDependencies : NpmDependency list
 }
 
+
 [<RequireQualifiedAccess>]
 type ResolveAction =
-    | Install of package:string * library:string * version:string
-    | Uninstall of package:string * library: string * version:string
-    | UnableToResolve of package:string * library:string * range:string * error: string
+    | Install of library:string * package:string * version:string * range: string
+    | InstallDev of library:string * package:string * version:string * range: string
+    | Uninstall of library:string * package: string * version:string
+    | UninstallDev of library:string * package: string * version:string
+    | UnableToResolve of library:string * package:string * range:string * error: string
 
 let findLibraryWithNpmDeps (project: CrackedFsproj) =
     [ yield project.ProjectFile
@@ -79,20 +82,32 @@ let findInstalledPackages (packageJson: string) : ResizeArray<InstalledNpmPackag
     let dependencies : JProperty list = [
         if content.ContainsKey "dependencies"
         then yield! (content.["dependencies"] :?> JObject).Properties() |> List.ofSeq
+    ]
 
+    let devDependencies = [
         if content.ContainsKey "devDependencies"
         then yield! (content.["devDependencies"] :?> JObject).Properties() |> List.ofSeq
-
-        if content.ContainsKey "peerDependencies"
-        then yield! (content.["peerDependencies"] :?> JObject).Properties() |> List.ofSeq
     ]
 
     let topLevelPackages = ResizeArray [
-        for package in dependencies -> {
-            Name = package.Name;
-            Range = Some (SemVer.Range(package.Value.ToObject<string>()));
-            Installed = None
-        }
+        yield! [
+            for package in dependencies -> {
+                Name = package.Name;
+                Range = Some (SemVer.Range(package.Value.ToObject<string>()));
+                Installed = None
+                DevDependency = false
+            }
+        ]
+
+        yield! [
+            for package in devDependencies -> {
+                Name = package.Name;
+                Range = Some (SemVer.Range(package.Value.ToObject<string>()));
+                Installed = None
+                DevDependency = true
+            }
+        ]
+
     ]
 
     if needsNodeModules packageJson
@@ -223,18 +238,39 @@ let rec autoResolveActions
                     let error = "Could not find a version that satisfies the required range"
                     [ ResolveAction.UnableToResolve(library.Name, package.Name, package.RawVersion, error) ]
                 | Some version ->
-                    [ ResolveAction.Install(library.Name, package.Name, version) ]
+                    if package.DevDependency then
+                        [ ResolveAction.InstallDev(library.Name, package.Name, version, package.RawVersion) ]
+                    else
+                        [ ResolveAction.Install(library.Name, package.Name, version, package.RawVersion) ]
 
             | Some installedPackage ->
                 // already installed -> check whether it falls under the required constraint
-                match installedPackage.Range, installedPackage.Installed with
-                | Some range, Some installedVersion ->
+                match  installedPackage.Installed with
+                | Some installedVersion ->
+                    // check installed version satisfies package constraint
                     match package.Constraint with
                     | Some requiredRange  ->
                         if requiredRange.IsSatisfied installedVersion
                         then
-                            // no need to do anything
-                            [ ]
+                            // versions are correct, check if they are both devDepdendenicies or both dependencies
+                            if package.DevDependency && not installedPackage.DevDependency then
+                                [
+                                    // uninstall from "dependencies"
+                                    ResolveAction.Uninstall(library.Name, installedPackage.Name, installedVersion.ToString())
+                                    // re-install as "devDependency"
+                                    ResolveAction.InstallDev(library.Name, package.Name, installedVersion.ToString(), package.RawVersion)
+                                ]
+                            elif not package.DevDependency && installedPackage.DevDependency then
+                                [
+                                    // uninstall from "devDependencies"
+                                    ResolveAction.UninstallDev(library.Name, installedPackage.Name, installedVersion.ToString())
+                                    // re-install into "dependencies"
+                                    ResolveAction.Install(library.Name, package.Name, installedVersion.ToString(), package.RawVersion)
+                                ]
+                            else
+                                // both are either "devDependencies" or "dependencies"
+                                // nothing left to do
+                                [ ]
                         else
                             // installed version falls outside of required range
                             // resolve version from required range
@@ -243,9 +279,13 @@ let rec autoResolveActions
                             | Some resolvedVersion ->
                                 [
                                     // uninstall current
-                                    ResolveAction.Uninstall(library.Name, installedPackage.Name, installedVersion.ToString())
-                                    // resolve using the resolved version
-                                    ResolveAction.Install(library.Name, package.Name, resolvedVersion)
+                                    if installedPackage.DevDependency
+                                    then yield ResolveAction.UninstallDev(library.Name, installedPackage.Name, installedVersion.ToString())
+                                    else yield ResolveAction.Uninstall(library.Name, installedPackage.Name, installedVersion.ToString())
+                                    // Re-install using the resolved version
+                                    if package.DevDependency
+                                    then yield ResolveAction.InstallDev(library.Name, package.Name, resolvedVersion, package.RawVersion)
+                                    else yield ResolveAction.Install(library.Name, package.Name, resolvedVersion, package.RawVersion)
                                 ]
 
                             | None ->
@@ -359,22 +399,189 @@ let defaultCliArgs = {
     ResolvePreview = false
 }
 
+let resolveConflicts (actions: ResolveAction list) =
+    // remove duplicate uninstall commands
+    let distinctUninstallActions =
+        actions
+        |> List.choose (function
+            | ResolveAction.Uninstall(library, pkg, version) -> Some(library, pkg, version, false)
+            | ResolveAction.UninstallDev(library, pkg, version) -> Some (library, pkg, version, true)
+            | _ -> None)
+        |> List.distinctBy (fun (lib, pkg, version, isDev) -> pkg)
+        |> List.map (fun (lib, pkg, version, isDev) ->
+            if isDev
+            then ResolveAction.UninstallDev(lib, pkg, version)
+            else ResolveAction.Uninstall(lib, pkg, version))
+
+    let distinctInstallActions =
+        actions
+        |> List.choose (function
+            | ResolveAction.Install(lib, package, version, range) -> Some(lib, package, version, range)
+            | _ -> None)
+        // distinct by the combination of version and range
+        |> List.distinctBy (fun (_, _, version, range) -> version, range)
+        // group duplicate package install commands
+        // try find a version that satisfies all ranges
+        |> List.groupBy (fun (_, pkg, _, _) -> pkg)
+        |> List.map (fun (pkgName, packages) ->
+            match packages with
+            | [ (lib, _, version, range) ] ->
+                // make sure the library was did not have an unresolvable version
+                actions
+                |> List.choose (function
+                    | ResolveAction.UnableToResolve(lib, pkg, range, error) when pkg = pkgName -> Some(SemVer.Range(range))
+                    | _ -> None)
+                |> List.tryHead
+                |> function
+                    | None -> ResolveAction.Install(lib, pkgName, version, range)
+                    | Some problematicRange ->
+                        if not (problematicRange.IsSatisfied (SemVer.Version(version)))
+                        then
+                            let errorMsg = sprintf "Resolved version %s satisfies [%s] but not %s" version range (problematicRange.ToString())
+                            ResolveAction.UnableToResolve(lib, pkgName, problematicRange.ToString(), errorMsg)
+                        else
+                            ResolveAction.Install(lib, pkgName, version, range)
+
+            | multiplePackages ->
+                let libName = multiplePackages |> List.map (fun (lib, _, _, _) -> lib) |> List.head
+                let ranges = multiplePackages |> List.map (fun (_, _, _, range) -> SemVer.Range range)
+                let versions = multiplePackages |> List.map (fun (_, _, version, _ ) -> SemVer.Version version)
+                // find a version that satisfies all ranges
+                versions
+                |> List.tryFind (fun version -> ranges |> List.forall (fun range -> range.IsSatisfied version))
+                |> function
+                    | None ->
+                        // could not find a version that satisfies all ranges
+                        // find a sample version that doesn't satisfy a sample range and report them
+                        let rangeStrings = multiplePackages |> List.map (fun (_, _, _, range) -> range)
+                        let errorMsg = sprintf "Could not find a version that satisfies the ranges [%s]" (String.concat ", " rangeStrings)
+                        ResolveAction.UnableToResolve(libName, pkgName, String.concat ", " rangeStrings, errorMsg)
+
+                    | Some version ->
+                        // found a version that satisfies all versions!
+                        // look ranges that weren't resolved
+                        let rangeStrings = multiplePackages |> List.map (fun (_, _, _, range) -> range)
+
+                        actions
+                        |> List.choose (function
+                            | ResolveAction.UnableToResolve(lib, pkg, range, error) when pkg = pkgName -> Some(SemVer.Range(range))
+                            | _ -> None)
+                        |> List.tryHead
+                        |> function
+                            | None ->
+                                ResolveAction.Install(libName, pkgName, version.ToString(), String.concat " || " rangeStrings)
+                            | Some problematicRange ->
+                                if not (problematicRange.IsSatisfied version)
+                                then
+                                    let errorMsg = sprintf "Resolved version %s satisfies [%s] but not %s" (version.ToString()) (String.concat " || " rangeStrings) (problematicRange.ToString())
+                                    ResolveAction.UnableToResolve(libName, pkgName, problematicRange.ToString(), errorMsg)
+                                else
+                                    ResolveAction.Install(libName, pkgName, version.ToString(), String.concat " || " rangeStrings)
+        )
+
+    let distinctInstallDevActions =
+        actions
+        |> List.choose (function
+            | ResolveAction.InstallDev(lib, package, version, range) -> Some(lib, package, version, range)
+            | _ -> None)
+        // distinct by the combination of version and range
+        |> List.distinctBy (fun (_, _, version, range) -> version, range)
+        // group duplicate package install commands
+        // try find a version that satisfies all ranges
+        |> List.groupBy (fun (_, pkg, _, _) -> pkg)
+        |> List.map (fun (pkgName, packages) ->
+            match packages with
+            | [ (lib, _, version, range) ] ->
+                // make sure the library was did not have an unresolvable version
+                actions
+                |> List.choose (function
+                    | ResolveAction.UnableToResolve(lib, pkg, range, error) when pkg = pkgName -> Some(SemVer.Range(range))
+                    | _ -> None)
+                |> List.tryHead
+                |> function
+                    | None -> ResolveAction.InstallDev(lib, pkgName, version, range)
+                    | Some problematicRange ->
+                        if not (problematicRange.IsSatisfied (SemVer.Version(version)))
+                        then
+                            let errorMsg = sprintf "Resolved version %s satisfies [%s] but not %s" version range (problematicRange.ToString())
+                            ResolveAction.UnableToResolve(lib, pkgName, problematicRange.ToString(), errorMsg)
+                        else
+                            ResolveAction.InstallDev(lib, pkgName, version, range)
+
+            | multiplePackages ->
+                let libName = multiplePackages |> List.map (fun (lib, _, _, _) -> lib) |> List.head
+                let ranges = multiplePackages |> List.map (fun (_, _, _, range) -> SemVer.Range range)
+                let versions = multiplePackages |> List.map (fun (_, _, version, _ ) -> SemVer.Version version)
+                // find a version that satisfies all ranges
+                versions
+                |> List.tryFind (fun version -> ranges |> List.forall (fun range -> range.IsSatisfied version))
+                |> function
+                    | None ->
+                        // could not find a version that satisfies all ranges
+                        // find a sample version that doesn't satisfy a sample range and report them
+                        let rangeStrings = multiplePackages |> List.map (fun (_, _, _, range) -> range)
+                        let errorMsg = sprintf "Could not find a version that satisfies the ranges [%s]" (String.concat ", " rangeStrings)
+                        ResolveAction.UnableToResolve(libName, pkgName, String.concat ", " rangeStrings, errorMsg)
+
+                    | Some version ->
+                        // found a version that satisfies all versions!
+                        // look ranges that weren't resolved
+                        let rangeStrings = multiplePackages |> List.map (fun (_, _, _, range) -> range)
+
+                        actions
+                        |> List.choose (function
+                            | ResolveAction.UnableToResolve(lib, pkg, range, error) when pkg = pkgName -> Some(SemVer.Range(range))
+                            | _ -> None)
+                        |> List.tryHead
+                        |> function
+                            | None ->
+                                ResolveAction.InstallDev(libName, pkgName, version.ToString(), String.concat " || " rangeStrings)
+                            | Some problematicRange ->
+                                if not (problematicRange.IsSatisfied version)
+                                then
+                                    let errorMsg = sprintf "Resolved version %s satisfies [%s] but not %s" (version.ToString()) (String.concat " || " rangeStrings) (problematicRange.ToString())
+                                    ResolveAction.UnableToResolve(libName, pkgName, problematicRange.ToString(), errorMsg)
+                                else
+                                    ResolveAction.InstallDev(libName, pkgName, version.ToString(), String.concat " || " rangeStrings)
+        )
+
+    let unresolvableActions =
+        actions
+        |> List.filter (function
+            | ResolveAction.UnableToResolve (_) -> true
+            | _ -> false)
+
+    List.concat [
+        distinctUninstallActions
+        distinctInstallDevActions
+        distinctInstallActions
+        unresolvableActions
+    ]
+
 let executeResolutionActions (cwd: string) (manager: NodeManager) (actions: ResolveAction list) =
+    let actions = resolveConflicts actions
+
     let uninstallPackages =
         actions |> List.choose (function
-        | ResolveAction.Uninstall(_, pkg, _)-> Some pkg
+        | ResolveAction.Uninstall(_, pkg, _) -> Some pkg
+        | ResolveAction.UninstallDev(_, pkg, _) -> Some pkg
         | _ -> None)
 
-    let installPackages =
+    let dependenciesToInstall =
         actions |> List.choose (function
-        | ResolveAction.Install(_, pkg, version)-> Some (pkg, version)
+        | ResolveAction.Install(_, pkg, version, range)-> Some (pkg, version)
+        | _ -> None)
+
+    let devDependenciesToInstall =
+        actions |> List.choose (function
+        | ResolveAction.InstallDev(_, pkg, version, range)-> Some (pkg, version)
         | _ -> None)
 
     if not (List.isEmpty uninstallPackages) then
         // then there some packages we need to uninstall first
         let program, args =
             match manager with
-            | NodeManager.Npm -> "npm", [ yield "uninstall"; yield! uninstallPackages; yield "--save" ]
+            | NodeManager.Npm -> "npm", [ yield "uninstall"; yield! uninstallPackages ]
             | NodeManager.Yarn -> "yarn", [ yield "remove"; yield! uninstallPackages ]
 
         logger.Information("Uninstalling [{Libraries}]", String.concat ", " uninstallPackages)
@@ -385,10 +592,10 @@ let executeResolutionActions (cwd: string) (manager: NodeManager) (actions: Reso
         |> Proc.run
         |> ignore
 
-    if not (List.isEmpty installPackages) then
+    if not (List.isEmpty dependenciesToInstall) then
         // there are packages that need to be installed
         let packagesToInstall =
-            installPackages
+            dependenciesToInstall
             |> List.map (fun (package, version) -> sprintf "%s@%s" package version)
 
         let program, args =
@@ -400,6 +607,25 @@ let executeResolutionActions (cwd: string) (manager: NodeManager) (actions: Reso
         CreateProcess.xplatCommand program args
         |> CreateProcess.withWorkingDirectory cwd
         |> CreateProcess.ensureExitCodeWithMessage (sprintf "Error while installing %s" (String.concat ", " packagesToInstall))
+        |> CreateProcess.redirectOutput
+        |> Proc.run
+        |> ignore
+
+    if not (List.isEmpty devDependenciesToInstall) then
+        // there are packages that need to be installed
+        let packagesToInstall =
+            devDependenciesToInstall
+            |> List.map (fun (package, version) -> sprintf "%s@%s" package version)
+
+        let program, args =
+            match manager with
+            | NodeManager.Npm -> "npm", [ yield "install"; yield! packagesToInstall; yield "--save-dev" ]
+            | NodeManager.Yarn -> "yarn", [ yield "add"; yield! packagesToInstall; yield "--dev" ]
+
+        logger.Information("Installing dev [{Libraryies}]", String.concat ", " packagesToInstall)
+        CreateProcess.xplatCommand program args
+        |> CreateProcess.withWorkingDirectory cwd
+        |> CreateProcess.ensureExitCodeWithMessage (sprintf "Error while installing dev %s" (String.concat ", " packagesToInstall))
         |> CreateProcess.redirectOutput
         |> Proc.run
         |> ignore
@@ -496,8 +722,8 @@ let rec private runner (args : FemtoArgs) =
                 for library in libraries do
                     for pkg in library.NpmDependencies do
                         logger.Information("{Library} requires npm package {Package} ({Version})", library.Name, pkg.Name, pkg.RawVersion)
-                logger.Warning "Could not locate package.json file"
 
+                logger.Warning "Could not locate package.json file"
                 FemtoResult.MissingPackageJson
 
             | Some packageJson ->
@@ -524,16 +750,21 @@ let rec private runner (args : FemtoArgs) =
                     if args.ResolvePreview then
                         logger.Information("Previewing required actions for package resolution")
                         let resolveActions = autoResolve nodeManager libraries installedPackages []
-                        if List.isEmpty resolveActions then
+                        let simplifiedActions = resolveConflicts resolveActions
+                        if List.isEmpty simplifiedActions then
                             logger.Information("√ Required packages are already resolved")
                             FemtoResult.ValidationSucceeded
                         else
-                        for action in resolveActions do
+                        for action in simplifiedActions do
                             match action with
-                            | ResolveAction.Install(lib, pkg, version) ->
-                                logger.Information("{Library} -> Install {Package} version {Version}", lib, pkg, version)
+                            | ResolveAction.Install(lib, pkg, version, range) ->
+                                logger.Information("{Library} -> Install {Package} version {Version} satisfies [{Range}]", lib, pkg, version, range)
+                            | ResolveAction.InstallDev(lib, pkg, version, range) ->
+                                logger.Information("{Library} -> Install {Package} (dev) version {Version} satisfies [{Range}]", lib, pkg, version, range)
                             | ResolveAction.Uninstall(lib, pkg, version) ->
                                 logger.Information("{Library} -> Uninstall {Package} version {Version}", lib, pkg, version)
+                            | ResolveAction.UninstallDev(lib, pkg, version) ->
+                                logger.Information("{Library} -> Uninstall {Package} (dev) version {Version}", lib, pkg, version)
                             | ResolveAction.UnableToResolve(lib, pkg, range, error) ->
                                 logger.Error("{Library} -> Unable to resolve version for {Package} within {Range}", lib, pkg, range)
                                 logger.Error(error)


### PR DESCRIPTION
Fixes #21 and Fixes #29 

First of all: my head hurts 😅 everything seems to work like it should but I think some more manual tests would be greate (please @MangelMaxime 🙏)

### Conflict Resolution

This PR implements conflict resolution when you require the *same* package multiple times for different version ranges, Femto will try to resolve a specific version that satisfies all version ranges. Example `Fable.DateFunctions` where it is a project reference of `App.fsproj`
```xml
  <PropertyGroup>
    <NpmDependencies>
      <NpmPackage Name="date-fns" Version=">= 1.0 lt 2.0" />
      <NpmPackage Name="date-fns" Version=">= 1.20 lt 2.0" />
    </NpmDependencies>
  </PropertyGroup>
```
Normally these different packages would be required by different projects but the sake of testing I am using a single project. 
Now running `femto --preview` against project `App.fsproj` will give the following:
```
[02:15:10 INF] Analyzing project C:\projects\Fable.DateFunctions\app\App.fsproj
[02:15:14 INF] Found package.json in C:\projects\Fable.DateFunctions
[02:15:14 INF] Using yarn for package management
[02:15:14 INF] Previewing required actions for package resolution
[02:15:15 INF] Fable.DateFunctions -> Install date-fns version 1.20.0 satisfies [>= 1.0 < 2.0 && >= 1.20 < 2.0]
```
Now adding an impossible version range such as `>= 5.0` as follows:
```xml
  <PropertyGroup>
    <NpmDependencies>
      <NpmPackage Name="date-fns" Version=">= 1.0 lt 2.0" />
      <NpmPackage Name="date-fns" Version=">= 1.20 lt 2.0" />
      <NpmPackage Name="date-fns" Version=">= 5.0" />
    </NpmDependencies>
  </PropertyGroup>
```
Gives the following logs
```
[02:14:34 INF] Analyzing project C:\projects\Fable.DateFunctions\app\App.fsproj
[02:14:37 INF] Found package.json in C:\projects\Fable.DateFunctions
[02:14:37 INF] Using yarn for package management
[02:14:37 INF] Previewing required actions for package resolution
[02:14:39 ERR] Fable.DateFunctions -> Unable to resolve version for date-fns within >= 5.0
[02:14:39 ERR] Resolved version 1.20.0 satisfies [>= 1.0 < 2.0 && >= 1.20 < 2.0] but not >= 5.0
[02:14:39 ERR] Fable.DateFunctions -> Unable to resolve version for date-fns within >= 5.0
[02:14:39 ERR] Could not find a version that satisfies the required range
```
You might think that these logs are duplicates but actually the second error messages tells from which project the invalid version range is specified. 

### Developement dependencies

Now you can specify whether your npm dependencies should go in `dependencies` or `devDependencies` based on the attribute `DevDependency` in the XML tags:
```xml
<NpmDependencies>
  <NpmPackage Name="date-fns" Version=">= 1.0 lt 2.0" DevDependency="true" />
</NpmDependencies>
```
If the developer installed this package by mistake into `dependencies` it will be uninstalled and re-installed into `devDependencies` and vice-versa 

### General 

The code probably needs cleanup and some refactoring, this is the first working version of these two features 