### PR TITLE
68 Femto cannot use local paket

### DIFF
--- a/src/Program.fs
+++ b/src/Program.fs
@@ -1165,8 +1165,7 @@ let rec private installPackage (project: string) (installArgs: InstallArgs) (ori
                         FemtoResult.PaketFailed
             elif isPaketInstalledAsLocalCliTool projectRoot then
                 logger.Information("Using locally installed {Manager}", "paket")
-                paketInstallArgs
-                |> CreateProcess.xplatCommand "dotnet paket"
+                CreateProcess.xplatCommand "dotnet" ("paket" :: paketInstallArgs)
                 |> CreateProcess.withWorkingDirectory projectRoot
                 |> CreateProcess.redirectOutput
                 |> Proc.run
@@ -1182,7 +1181,7 @@ let rec private installPackage (project: string) (installArgs: InstallArgs) (ori
                               // workding directory
                               projectWorkingDir
                               // program
-                              "dotnet paket"
+                              "dotnet"
                               // args
                               (String.concat " " paketInstallArgs)
                         logger.Error("Error while running the following command:")
@@ -1336,8 +1335,7 @@ and private uninstallPackage (project: string) (package: string) =
                         FemtoResult.PaketFailed
             elif isPaketInstalledAsLocalCliTool projectRoot then
                 logger.Information("Using locally installed {Manager}", "paket")
-                paketInstallArgs
-                |> CreateProcess.xplatCommand "dotnet paket"
+                CreateProcess.xplatCommand "dotnet" ("paket" :: paketInstallArgs)
                 |> CreateProcess.withWorkingDirectory projectRoot
                 |> CreateProcess.redirectOutput
                 |> Proc.run


### PR DESCRIPTION
Hi,

I think I found this one.

I tried following fsx script. If xplatCommand is called iwth "dotnet paket" it does not work but if "paket" is added as argument and xplatCommand is called just with "dotnet" it works.

```
#r "nuget: Fake.Core.Process, Version=5.15.0"

open System.IO
open Fake.Core

module CreateProcess =
    /// Creates a cross platfrom command from the given program and arguments.
    ///
    /// For example:
    ///
    /// ```fsharp
    /// CreateProcess.xplatCommand "npm" [ "install" ]
    /// ```
    ///
    /// Will be the following on windows
    ///
    /// ```fsharp
    /// CreateProcess.fromRawCommand "cmd" [ "/C"; "npm"; "install" ]
    /// ```
    /// And the following otherwise
    ///
    /// ```fsharp
    /// CreateProcess.fromRawCommand "npm" [ "install" ]
    /// ```
    let xplatCommand program args =
        let program', args' =
            if Environment.isWindows
            then "cmd", List.concat [ [ "/C"; program ]; args ]
            else program, args

        CreateProcess.fromRawCommand program' args'


let projectRoot = @"<Some project root with paket installed as local tool."
let projectFileName = "Client.fsproj"

let paketInstallArgs = [ "paket"; "add"; "Feliz.MaterialUI"; "--project"; sprintf @"%s\%s" projectRoot projectFileName; "--group"; "Main" ]

let proc =
    paketInstallArgs
    |> CreateProcess.xplatCommand "dotnet"
    |> CreateProcess.withWorkingDirectory projectRoot
    |> CreateProcess.redirectOutput

proc.CommandLine // This works now with "paket" as argument and calling xplatCommand just with "dotnet" 

Proc.run proc
``` 