### PR TITLE
Display --version after install in the help

### DIFF
--- a/src/Program.fs
+++ b/src/Program.fs
@@ -1554,9 +1554,9 @@ type CLIArguments =
             | Project _ -> "specify the path to the F# project."
             | Validate -> "check that the XML tags used in the F# project file are parsable and a npm package version can be calculated."
             | Resolve -> "resolve and install required packages."
-            | Version _ -> "display the current version of Femto."
             | Install _ -> "install a package into a project"
             | Uninstall _ -> "uninstall a package from the project"
+            | Version _ -> "display the current version of Femto."
 
 let parseArgs (cliArgs : CLIArguments list) =
     let rec apply (cliArgs : CLIArguments list) (res : FemtoArgs) =


### PR DESCRIPTION
See https://github.com/Zaid-Ajaj/Femto/issues/76#issuecomment-930909254

With this, usage looks like this:

```
USAGE: femto [--help] [--validate] [--resolve] [install <package>] [uninstall <package>] [--version [<string>]] [<path>]
```