### PR TITLE
Fix #77: Ignore folders in node_modules starting with .

### DIFF
--- a/src/Program.fs
+++ b/src/Program.fs
@@ -119,30 +119,39 @@ let findInstalledPackages (packageJson: string) : ResizeArray<InstalledNpmPackag
         let siblings = IO.Directory.GetDirectories parentDir.FullName
         // using Array.find because we know for sure node_modules is present
         let nodeModulePath = siblings |> Array.find (fun dir -> dir.EndsWith "node_modules")
-        for dir in IO.Directory.GetDirectories nodeModulePath do
-            let pkgJson = IO.Path.Combine(dir, "package.json")
-            if not (IO.File.Exists pkgJson)
-                then ()
-            else
-                let nameAndVersionDecoder = Decode.object (fun get ->
-                    (get.Required.Field "name" Decode.string,
-                     get.Required.Field "version" Decode.string)
-                )
+        let rec checkPackageJsons nodeModulePath =
+            for dir in IO.Directory.GetDirectories nodeModulePath do
+                let dirname = IO.Path.GetFileName(dir)
+                let pkgJson = IO.Path.Combine(dir, "package.json")
+                // Some packages create a cache dir in node_modules starting with . like .vite
+                if dirname.StartsWith(".")
+                    then ()
+                // Scoped packages
+                elif dirname.StartsWith("@")
+                    then checkPackageJsons dir
+                if not (IO.File.Exists pkgJson)
+                    then ()
+                else
+                    let nameAndVersionDecoder = Decode.object (fun get ->
+                        (get.Required.Field "name" Decode.string,
+                         get.Required.Field "version" Decode.string)
+                    )
 
-                let decoded =
-                    File.readAllTextNonBlocking pkgJson
-                    |> Decode.fromString nameAndVersionDecoder
+                    let decoded =
+                        File.readAllTextNonBlocking pkgJson
+                        |> Decode.fromString nameAndVersionDecoder
 
-                match decoded with
-                | Ok (name, version) ->
-                    for package in topLevelPackages do
-                        if package.Name = name
-                        then package.Installed <- Some (SemVer.Version version)
-                        else ()
-                | Error errorMessage ->
-                    logger.Error("Couldn't decode 'package.json' from {PackageJson}. Reason: {Message}", pkgJson, errorMessage)
-                    ()
+                    match decoded with
+                    | Ok (name, version) ->
+                        for package in topLevelPackages do
+                            if package.Name = name
+                            then package.Installed <- Some (SemVer.Version version)
+                            else ()
+                    | Error errorMessage ->
+                        logger.Error("Couldn't decode 'package.json' from {PackageJson}. Reason: {Message}", pkgJson, errorMessage)
+                        ()
 
+        checkPackageJsons nodeModulePath
         topLevelPackages
 
 module CreateProcess =


### PR DESCRIPTION
Fix #77 by ignoring folders in node_modules starting with `.`

I also added recursion for scoped packages starting with `@`