### PR TITLE
Fix for failure when npm packages only have a single version.

### DIFF
--- a/src/Program.fs
+++ b/src/Program.fs
@@ -229,7 +229,11 @@ let private getPackageVersions (cwd: string option) (packageManager : PackageMan
             |> Proc.run
 
         if res.ExitCode = 0 then
-            let versions = Decode.unsafeFromString (Decode.list Decode.string) res.Result.Output
+            let npmDecoder = Decode.oneOf [
+                (Decode.list Decode.string)
+                (Decode.map List.singleton Decode.string)
+            ]
+            let versions = Decode.unsafeFromString npmDecoder res.Result.Output
             Some versions
         else
             None


### PR DESCRIPTION
**Issue**  
Femto throws an unhandled exception when an npm package has only a single version.

**Reason**  
The output of `npm show $package version --json` is unexpectedly a string, not a list of strings. This breaks the parser.

**Fix**  
A small change to the JSON parsing for npm, using `Decode.oneOf` to handle either output format.

