### PR TITLE
Fix: Parse name and version for YAML and JSON5 package files

### DIFF
--- a/src/NpmPackageFileParser.fs
+++ b/src/NpmPackageFileParser.fs
@@ -1,4 +1,4 @@
-module Femto.NpmPackageFileParser
+﻿module Femto.NpmPackageFileParser
 
 open Thoth.Json.Net
 open fastJSON5
@@ -11,9 +11,16 @@ type PackageFile = {
     [<YamlField("devDependencies")>] DevDependencies : Map<string, string> option
 }
 
+type PackageNameAndVersion = {
+    [<YamlField("name")>] Name: string
+    [<YamlField("version")>] Version: string
+}
+
 module Json5 =
     [<CLIMutable>]
     type Json5PackageFile = {
+        Name: string
+        Version: string
         Dependencies : Dictionary<string, string>
         DevDependencies : Dictionary<string, string>
     }
@@ -33,6 +40,13 @@ module Json5 =
         with
         | e -> Error e.Message
 
+    let parseNameAndVersion json5 =
+        try
+            let parseResult = JSON5.ToObject<Json5PackageFile>(json5)
+            Ok (parseResult.Name, parseResult.Version)
+        with
+        | e -> Error e.Message
+
 module Yaml =
     let parseDependencies yaml =
         match Legivel.Serialization.Deserialize<PackageFile> yaml with
@@ -44,9 +58,27 @@ module Yaml =
             |> Error
         | [] -> Error "No YAML document found"
 
+    let parseNameAndVersion yaml =
+        match Legivel.Serialization.Deserialize<PackageNameAndVersion> yaml with
+        | Legivel.Serialization.Success s :: _ -> Ok (s.Data.Name, s.Data.Version)
+        | Legivel.Serialization.Error e :: _ ->
+            e.Error
+            |> List.map _.Message
+            |> String.concat "\n"
+            |> Error
+        | [] -> Error "No YAML document found"
+
 module Json =
     let parseDependencies json =
         Decode.Auto.fromString<PackageFile>(json, isCamelCase = true)
+
+    let parseNameAndVersion =
+        let nameAndVersionDecoder = Decode.object (fun get ->
+            let name = get.Required.Field "name" Decode.string
+            let version = get.Required.Field "version" Decode.string
+            name, version
+        )
+        Decode.fromString nameAndVersionDecoder
 
 let parseDependencies packageFile =
     let file = IO.File.ReadAllText packageFile
@@ -56,3 +88,12 @@ let parseDependencies packageFile =
         Yaml.parseDependencies file
     else
         Json.parseDependencies file
+
+let parseNameAndVersion packageFile =
+    let file = File.readAllTextNonBlocking packageFile
+    if packageFile.EndsWith "json5" then
+        Json5.parseNameAndVersion file
+    elif packageFile.EndsWith "yaml" then
+        Yaml.parseNameAndVersion file
+    else
+        Json.parseNameAndVersion file

--- a/src/NpmPackageFileParser.fs
+++ b/src/NpmPackageFileParser.fs
@@ -1,4 +1,4 @@
-﻿module Femto.NpmPackageFileParser
+module Femto.NpmPackageFileParser
 
 open Thoth.Json.Net
 open fastJSON5
@@ -18,7 +18,7 @@ module Json5 =
         DevDependencies : Dictionary<string, string>
     }
 
-    let parse json5 =
+    let parseDependencies json5 =
         try
             let parseResult = JSON5.ToObject<Json5PackageFile>(json5)
             {
@@ -34,7 +34,7 @@ module Json5 =
         | e -> Error e.Message
 
 module Yaml =
-    let parse yaml =
+    let parseDependencies yaml =
         match Legivel.Serialization.Deserialize<PackageFile> yaml with
         | Legivel.Serialization.Success s :: _ -> Ok s.Data
         | Legivel.Serialization.Error e :: _ ->
@@ -45,14 +45,14 @@ module Yaml =
         | [] -> Error "No YAML document found"
 
 module Json =
-    let parse json =
+    let parseDependencies json =
         Decode.Auto.fromString<PackageFile>(json, isCamelCase = true)
 
-let parse packageFile =
+let parseDependencies packageFile =
     let file = IO.File.ReadAllText packageFile
     if packageFile.EndsWith "json5" then
-        Json5.parse file
+        Json5.parseDependencies file
     elif packageFile.EndsWith "yaml" then
-        Yaml.parse file
+        Yaml.parseDependencies file
     else
-        Json.parse file
+        Json.parseDependencies file

--- a/src/Program.fs
+++ b/src/Program.fs
@@ -182,15 +182,7 @@ let findInstalledPackages (packageFile: string) (packageManager: PackageManager)
                     let pkgFile = IO.Path.Combine(dir, packageFile)
                     // Some packages create a cache dir in node_modules starting with . like .vite
                     if not(dirname.StartsWith(".")) && IO.File.Exists pkgFile then
-                        let nameAndVersionDecoder = Decode.object (fun get ->
-                            let name = get.Required.Field "name" Decode.string
-                            let version = get.Required.Field "version" Decode.string
-                            name, version
-                        )
-
-                        let decoded =
-                            File.readAllTextNonBlocking pkgFile
-                            |> Decode.fromString nameAndVersionDecoder
+                        let decoded = NpmPackageFileParser.parseNameAndVersion pkgFile
 
                         match decoded with
                         | Ok (name, version) ->

--- a/src/Program.fs
+++ b/src/Program.fs
@@ -139,7 +139,7 @@ let findInstalledPackages (packageFile: string) (packageManager: PackageManager)
         packages
     else
     let topLevelPackages =
-        match NpmPackageFileParser.parse packageFile with
+        match NpmPackageFileParser.parseDependencies packageFile with
         | Ok rawPackage ->
             let createInstalledPackages isDevDependency (dependencies: Map<string, string> option) =
                  dependencies


### PR DESCRIPTION
I was testing out the new Femto version and found that I had missed out the parsing for the name and version for the package file. It does not affect the dependency checking, but errors will appear on the console due to using a JSON parser to parse YAML/JSON5 files.

This PR adds the parsing for name and version for YAML and JSON5 package files.